### PR TITLE
Added parameter feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes in this project is documented in this file. 
+
+## Unreleased [0.0.3]
+
+### Added
+- Parameter support.
+- `disablePastDays` parameter.
+- CHANGELOG file
+

--- a/index.html
+++ b/index.html
@@ -96,7 +96,11 @@
 	<script src="dist/vanillaCalendar.js" type="text/javascript"></script>
 	<script>
 		window.addEventListener('load', function () {
-		  vanillaCalendar.init();
+			var params = {
+				disablePastDays: true
+			};
+
+		  vanillaCalendar.init(params);
 		})
 	</script>
 </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vanilla-calendar",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A simple, hackable vanilla JS calendar",
   "main": "./src/vanillaCalendar.js",
   "scripts": {

--- a/src/vanillaCalendar.js
+++ b/src/vanillaCalendar.js
@@ -7,7 +7,9 @@ var vanillaCalendar = {
   date: new Date(),
   todaysDate: new Date(),
 
-  init: function() {
+  init: function(params) {
+    this.params = params;
+
     this.date.setDate(1);
     this.createMonth();
     this.createListeners();
@@ -46,7 +48,9 @@ var vanillaCalendar = {
       }
     }
 
-    if (this.date.getTime() <= this.todaysDate.getTime() - 1) {
+    var pastDaysDisabled = this.params && this.params['disablePastDays'];
+    if (pastDaysDisabled &&
+        this.date.getTime() <= this.todaysDate.getTime() - 1) {
       newDay.classList.add("vcal-date--disabled");
     } else {
       newDay.classList.add("vcal-date--active");


### PR DESCRIPTION
Added parameter support to the component.

For now, we only have `disablePastDays` parameter. We will add needed parameters later.

Usage:
```
  var params = {
      disablePastDays: true
  };

  vanillaCalendar.init(params);
```

Also added a changelog file, in order to document changes to this project.